### PR TITLE
Fix github action flow

### DIFF
--- a/.github/workflows/publishSite.yml
+++ b/.github/workflows/publishSite.yml
@@ -2,7 +2,9 @@ name: Publish Site
 on: 
   push:
     branches:
-      - master
+      - main
+    paths:
+      - 'src/**'
 jobs:
   report:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Pointing the github actions flow to build off of main now. Also only build of changes to the source files. Ignore the rest since they don't affect the output.